### PR TITLE
Changes in extract value method

### DIFF
--- a/src/AWSSecretManager.Configuration.Extension/AWSSecretManager.Configuration.Extension/AWSSecretManager.Configuration.Extension.csproj
+++ b/src/AWSSecretManager.Configuration.Extension/AWSSecretManager.Configuration.Extension/AWSSecretManager.Configuration.Extension.csproj
@@ -3,7 +3,7 @@
     <LangVersion>10</LangVersion>
     <TargetFramework>netstandard2.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.0.4</Version>
+    <Version>1.0.5</Version>
     <Company />
     <Authors>Manish Tiwari</Authors>
     <description>AWS Secret Manager configuration provider implementation for Microsoft.Extensions.Configuration.</description>

--- a/src/AWSSecretManager.Configuration.Extension/AWSSecretManager.Configuration.Extension/Internal/SecretsManagerConfigurationProvider.cs
+++ b/src/AWSSecretManager.Configuration.Extension/AWSSecretManager.Configuration.Extension/Internal/SecretsManagerConfigurationProvider.cs
@@ -60,7 +60,7 @@ namespace SecretManager.ConfigurationExtension.Internal
                 SetData(_loadedValues, triggerReload: true);
             }
         }
-        IEnumerable<(string key, string value)> ExtractValues(JsonElement jsonElement, string prefix)
+        IEnumerable<(string key, string value)> ExtractValues(JsonElement jsonElement, string secretKey)
         {
             switch (jsonElement.ValueKind)
             {
@@ -68,7 +68,6 @@ namespace SecretManager.ConfigurationExtension.Internal
                     {
                         for (var i = 0; i < jsonElement.GetArrayLength(); i++)
                         {
-                            var secretKey = $"{prefix}";
                             foreach (var (key, value) in ExtractValues(jsonElement[i], secretKey))
                             {
                                 yield return (key, value);
@@ -81,7 +80,7 @@ namespace SecretManager.ConfigurationExtension.Internal
                     {
                         foreach (var property in jsonElement.EnumerateObject())
                         {
-                            var secretKey = $"{prefix}" + "/" + property.Name;
+                            secretKey = property.Name;
                             if (property.Value.ValueKind != JsonValueKind.Null || property.Value.ValueKind != JsonValueKind.Undefined)
                             {
                                 foreach (var (key, value) in ExtractValues(property.Value, secretKey))
@@ -101,13 +100,13 @@ namespace SecretManager.ConfigurationExtension.Internal
                 case JsonValueKind.String:
                     {
                         var value = jsonElement.GetString();
-                        yield return (prefix, value);
+                        yield return (secretKey, value);
                         break;
                     }
                 case JsonValueKind.Number:
                     {
                         var value = jsonElement.GetInt32();
-                        yield return (prefix, value.ToString());
+                        yield return (secretKey, value.ToString());
                         break;
                     }
                 default:


### PR DESCRIPTION
- Removed prefix from the key in `JsonValueKind.Object` switch case
- Changed parameter name for `prefix` to `secretkey`
